### PR TITLE
Create group docker before creating docker-folder

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,11 @@
     groups: sudo
     append: yes
 
+- name: Create group docker
+  group:
+    name: docker
+    state: present
+
 - name: Create {{ docker_dir }} directory if needed
   file:
     path: '{{ docker_dir }}'


### PR DESCRIPTION
As described in https://github.com/ct-Open-Source/telerec-t-debian/issues/1 the system/task/main.yml tries to create the docker_folder with the owner group "docker", but this group does not exist at this moment.
Added task for creation of group docker before create docker_folder task